### PR TITLE
Update middleware config schema

### DIFF
--- a/.fly.yml
+++ b/.fly.yml
@@ -24,7 +24,7 @@ config:
     pathMatchMode: prefix
     pathPattern: "^\\/"
   middleware:
-  - https-upgrader
-  - - response-headers
-    - header_definition:
-        Powered-By: Caffeine
+  - type: https-upgrader
+  - type: response-headers
+    headers:
+      Powered-By: Caffeine

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -72,7 +72,7 @@ function compileRule(rule: RuleInfo) {
   const httpHeaderValue = ensureRegExp(rule.httpHeaderValue)
   const fn = function compiledRule(req: Request) {
     const url = new URL(req.url)
-    if (rule.matchScheme && rule.matchScheme != "") {
+    if (rule.matchScheme === "http" || rule.matchScheme === "https") {
       const scheme = url.protocol.substring(0, -1)
       if (scheme != rule.matchScheme || app.env === "development") return false
     }


### PR DESCRIPTION
Simplify the middleware schema by replacing the string or object array with an array of objects each containing a `type` property.
