### PR TITLE
Basic AWS S3 backend

### DIFF
--- a/.fly.secrets.yml
+++ b/.fly.secrets.yml
@@ -1,0 +1,2 @@
+aws_s3_access_key_id: ""
+aws_s3_secret_access_key: ""

--- a/.fly.yml
+++ b/.fly.yml
@@ -1,5 +1,4 @@
-app: cdn
-config:
+config: &config
   flyCDN:
     backends:
       getting-started:
@@ -12,3 +11,23 @@ config:
       backendKey: getting-started
     middleware:
     - type: https-upgrader
+
+default: &default
+  app: cdn
+  config:
+    <<: *config
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  config:
+    <<: *config
+    aws_s3_access_key_id:
+      fromSecret: aws_s3_access_key_id
+    aws_s3_secret_access_key:
+      fromSecret: aws_s3_secret_access_key
+
+production:
+  <<: *default

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ bin/fly
 .fly
 package-lock.json
 examples
-
+.fly.secrets.yml

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/superfly/cdn#readme",
   "dependencies": {
     "@fly/fly": "^0.44.5",
+    "@types/aws4": "^1.5.1",
     "http-cache-semantics": "^4.0.1",
     "lodash": "^4.17.11"
   },
@@ -42,8 +43,11 @@
     "@types/chai": "^4.1.7",
     "@types/lodash": "^4.14.119",
     "@types/mocha": "^5.2.5",
+    "@types/sjcl": "^1.0.28",
     "@types/source-map": "^0.5.2",
+    "aws4": "^1.8.0",
     "chai": "^4.2.0",
+    "sjcl": "^1.0.8",
     "standard-version": "^4.4.0",
     "ts-loader": "^3.5.0",
     "typedoc": "^0.13.0",

--- a/scripts/ci/azure-pipelines.yml
+++ b/scripts/ci/azure-pipelines.yml
@@ -17,6 +17,16 @@ steps:
 - script: |
     yarn install
   displayName: 'yarn install'
+- bash: |
+    echo "Generating fly secrets."
+
+    cat > .fly.secrets.yml <<EOL
+    aws_s3_access_key_id: ${AWS_S3_ACCESS_KEY_ID}
+    aws_s3_secret_access_key: ${AWS_S3_SECRET_ACCESS_KEY}
+    EOL
+  env:
+    AWS_S3_ACCESS_KEY_ID: $(aws_s3_access_key_id)
+    AWS_S3_SECRET_ACCESS_KEY: $(aws_s3_secret_access_key)
 - script: |
     yarn test
   displayName: 'yarn test'

--- a/scripts/ci/secrets.sh
+++ b/scripts/ci/secrets.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "Generating fly secrets."
+
+cat > .fly.secrets.yml <<EOL
+aws_s3_access_key_id: ${AWS_S3_ACCESS_KEY_ID}
+aws_s3_secret_access_key: ${AWS_S3_SECRET_ACCESS_KEY}
+EOL

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -1,0 +1,31 @@
+import * as aws4 from 'aws4';
+
+export interface Credentials {
+    accessKeyId: string,
+    secretAccessKey: string,
+    sessionToken?: string, // only required for temporary credentials
+}
+
+export interface RequestOptions {
+    path: string,
+    host?: string,
+    method?: string,
+    headers?: any,
+    service?: string,
+    region?: string,
+}
+
+const aws = {
+    fetch(opts: RequestOptions, credentials: Credentials) {
+        let signer = new aws4.RequestSigner(opts, credentials);
+        signer.request.protocol = 'https:';
+        signer.sign();
+        const req = signer.request;
+        let url = `${req.protocol}//${req.hostname}${req.path}`
+        console.debug("AWS S3 requesting URL:", url)
+        return fetch(url, { method: req.method, headers: req.headers });
+    },
+    sign: aws4.sign
+}
+
+export default aws;

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -1,4 +1,4 @@
-import * as aws4 from 'aws4';
+import { RequestSigner, sign } from 'aws4';
 
 export interface Credentials {
     accessKeyId: string,
@@ -17,7 +17,7 @@ export interface RequestOptions {
 
 const aws = {
     fetch(opts: RequestOptions, credentials: Credentials) {
-        let signer = new aws4.RequestSigner(opts, credentials);
+        let signer = new RequestSigner(opts, credentials);
         signer.request.protocol = 'https:';
         signer.sign();
         const req = signer.request;
@@ -25,7 +25,7 @@ const aws = {
         console.debug("AWS S3 requesting URL:", url)
         return fetch(url, { method: req.method, headers: req.headers });
     },
-    sign: aws4.sign
+    sign
 }
 
 export default aws;

--- a/src/backends.ts
+++ b/src/backends.ts
@@ -8,3 +8,4 @@ export * from "./backends/ghost_pro";
 export * from "./backends/heroku";
 export * from "./backends/netlify";
 export * from "./backends/echo";
+export * from "./backends/aws_s3";

--- a/src/backends/aws_s3.ts
+++ b/src/backends/aws_s3.ts
@@ -1,12 +1,37 @@
+/**
+ * @module Backends
+ */
 import { FetchFunction } from '../fetch';
 import aws, { Credentials } from '../aws'
 
+/**
+ * AWS S3 bucket options
+ */
 export interface AwsS3Options {
     bucket: string,
     region?: string,
     credentials?: Credentials
 }
 
+/**
+ * Creates a fetch-like proxy function for making requests to AWS S3.
+ * 
+ * Example:
+ * 
+ * ```typescript
+ * import { awsS3 } from "./src/backends";
+ * const backend = awsS3({
+ *  bucket: "flyio-test-website",
+ *  // region: "us-east-1"
+ *  // credentials: { // for private S3 buckets
+ *  //   accessKeyId: app.config.aws_access_key_id,
+ *  //   secretAccessKey: app.config.aws_secret_access_key, // store this as a secret
+ *  // }
+ * });
+ * ```
+ * @param options AWS S3 bucket to proxy to
+ * @module Backends
+ */
 export function awsS3(options: AwsS3Options | string): FetchFunction {
     const opts = normalizeOptions(options);
     return async function awsS3Fetch(req: RequestInfo, init?: RequestInit): Promise<Response> {

--- a/src/backends/aws_s3.ts
+++ b/src/backends/aws_s3.ts
@@ -1,0 +1,43 @@
+import { FetchFunction } from '../fetch';
+import aws, { Credentials } from '../aws'
+
+export interface AwsS3Options {
+    bucket: string,
+    region?: string,
+    credentials?: Credentials
+}
+
+export function awsS3(options: AwsS3Options | string): FetchFunction {
+    const opts = normalizeOptions(options);
+    return async function awsS3Fetch(req: RequestInfo, init?: RequestInit): Promise<Response> {
+        if (typeof req === "string") req = new Request(req, init);
+        const url = new URL(req.url);
+        if (typeof opts.credentials === 'object') {
+            return aws.fetch({
+                path: `/${opts.bucket}${url.pathname}`,
+                service: 's3',
+                region: opts.region,
+            }, opts.credentials);
+        }
+        const publicUrl = buildS3Url(opts, url.pathname);
+        return fetch(publicUrl, { headers: req.headers })
+    }
+}
+
+function normalizeOptions(options: AwsS3Options | string): AwsS3Options {
+    if (typeof options === 'string')
+        options = { bucket: options }
+    return options
+}
+
+function buildS3Url(opts: AwsS3Options, path: string): string {
+    const region = opts.region || 'us-east-1';
+    let host: string;
+    if (region === 'us-east-1') {
+        host = "s3.amazonaws.com"
+    } else {
+        host = `s3-${opts.region}.amazonaws.com`
+    }
+
+    return `http://${host}/${opts.bucket}${path}`
+}

--- a/src/shims/crypto.ts
+++ b/src/shims/crypto.ts
@@ -1,0 +1,28 @@
+import * as sjcl from 'sjcl'
+
+export function createHmac(_algo: string, key: string | sjcl.BitArray) {
+    const mac = new sjcl.misc.hmac(typeof key === 'string' ? sjcl.codec.utf8String.toBits(key) : key);
+    return {
+        update: (data: string) => {
+            mac.update(data);
+            return {
+                digest: (encoding: string) => {
+                    let result = mac.digest();
+                    return encoding === 'hex' ? sjcl.codec.hex.fromBits(result) : result;
+                },
+            };
+        },
+    };
+}
+
+export function createHash() {
+    const hash = new sjcl.hash.sha256();
+    return {
+        update: (data: string) => {
+            hash.update(data);
+            return {
+                digest: () => sjcl.codec.hex.fromBits(hash.finalize()),
+            };
+        },
+    };
+}

--- a/test/backends/aws_s3.spec.ts
+++ b/test/backends/aws_s3.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { backends } from "../../src"
+
+const { awsS3 } = backends
+
+describe("backends/awsS3", () => {
+    describe("public", () => {
+        it('works', async () => {
+            const fn = awsS3("flyio-test-website");
+            const resp = await fn("/index.html");
+            expect(resp.status).to.eq(200);
+        })
+    })
+
+    describe("w/ options", () => {
+        it('works', async () => {
+            const fn = awsS3({ bucket: "flyio-test-website" });
+            const resp = await fn("/index.html");
+            expect(resp.status).to.eq(200);
+        })
+    })
+
+    describe("private", () => {
+        if (app.config.aws_s3_secret_access_key)
+            it('works', async () => {
+                console.log(JSON.stringify(app))
+                const fn = awsS3({
+                    bucket: "flyio-private-website",
+                    credentials: {
+                        accessKeyId: app.config.aws_s3_access_key_id,
+                        secretAccessKey: app.config.aws_s3_secret_access_key
+                    }
+                });
+                const resp = await fn("/index.html");
+                expect(resp.status).to.eq(200);
+            })
+        else
+            it('works (did not run, missing proper secrets)')
+    })
+
+})

--- a/test/backends/aws_s3.spec.ts
+++ b/test/backends/aws_s3.spec.ts
@@ -23,7 +23,6 @@ describe("backends/awsS3", () => {
     describe("private", () => {
         if (app.config.aws_s3_secret_access_key)
             it('works', async () => {
-                console.log(JSON.stringify(app))
                 const fn = awsS3({
                     bucket: "flyio-private-website",
                     credentials: {

--- a/test/backends/aws_s3.spec.ts
+++ b/test/backends/aws_s3.spec.ts
@@ -11,6 +11,7 @@ describe("backends/awsS3", () => {
             expect(resp.status).to.eq(200);
             for (let h in resp.headers)
                 expect(h.startsWith("x-amz-")).to.eq(false)
+            expect(resp.headers.get("etag")).to.not.be.empty
         })
         it("uses index.html by default", async () => {
             const fn = awsS3("flyio-test-website");
@@ -18,6 +19,14 @@ describe("backends/awsS3", () => {
             expect(resp.status).to.eq(200);
             for (let h in resp.headers)
                 expect(h.startsWith("x-amz-")).to.eq(false)
+        })
+        it("responds to HEAD requests correctly", async () => {
+            const fn = awsS3("flyio-test-website");
+            const resp = await fn("/", { method: "HEAD" });
+            expect(resp.status).to.eq(200);
+            for (let h in resp.headers)
+                expect(h.startsWith("x-amz-")).to.eq(false)
+            expect(await resp.text()).to.be.empty
         })
         describe("w/ options", () => {
             it("responds with the file's content", async () => {
@@ -29,18 +38,44 @@ describe("backends/awsS3", () => {
             })
         })
         describe("error handling", () => {
-            it("returns a 404 when file is not found", async () => {
+            it("return an error for anything other than GET or HEAD methods", async () => {
+                for (let method of ["POST", "PUT", "PATCH", "DELETE", "TRACE", "CONNECT", "GIBBERISH"]) {
+                    let resp = await awsS3({ bucket: "flyio-test-website" })("/index.html", { method })
+                    expect(resp.status).to.eq(405)
+                }
+            })
+            it("GET returns a 404 when file is not found", async () => {
                 const fn = awsS3({ bucket: "flyio-test-website" });
                 const resp = await fn("/index2.html");
                 expect(resp.status).to.eq(404);
                 for (let h in resp.headers)
                     expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
             })
+            it("HEAD returns a 404 when file is not found", async () => {
+                const fn = awsS3({ bucket: "flyio-test-website" });
+                const resp = await fn("/index2.html", { method: "HEAD" });
+                expect(resp.status).to.eq(404);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
+                expect(resp.body).to.be.null
+            })
         })
     })
 
     describe("private", () => {
         describe("error handling", () => {
+            it("return an error for anything other than GET or HEAD methods", async () => {
+                for (let method of ["POST", "PUT", "PATCH", "DELETE", "TRACE", "CONNECT", "GIBBERISH"]) {
+                    let resp = await awsS3({
+                        bucket: "flyio-private-website",
+                        credentials: {
+                            accessKeyId: "gibberish",
+                            secretAccessKey: "gibberish"
+                        }
+                    })("/index.html", { method })
+                    expect(resp.status).to.eq(405)
+                }
+            })
             it("returns a 500 when credentials are off", async () => {
                 const fn = awsS3({
                     bucket: "flyio-private-website",
@@ -56,10 +91,10 @@ describe("backends/awsS3", () => {
             })
 
             if (!app.config.aws_s3_secret_access_key) {
-                it('500 when access denied might work (did not run, missing proper secrets)');
+                it('404 might work (did not run, missing proper secrets)');
                 return
             }
-            it("returns a 500 when a file is not found (aws: access denied)", async () => {
+            it("GET returns a 404 when a file is not found", async () => {
                 const fn = awsS3({
                     bucket: "flyio-private-website",
                     credentials: {
@@ -68,9 +103,23 @@ describe("backends/awsS3", () => {
                     }
                 });
                 const resp = await fn("/index2.html");
-                expect(resp.status).to.eq(500);
+                expect(resp.status).to.eq(404);
                 for (let h in resp.headers)
                     expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
+            })
+            it("HEAD returns a 404 when a file is not found", async () => {
+                const fn = awsS3({
+                    bucket: "flyio-private-website",
+                    credentials: {
+                        accessKeyId: app.config.aws_s3_access_key_id,
+                        secretAccessKey: app.config.aws_s3_secret_access_key
+                    }
+                });
+                const resp = await fn("/index2.html", { method: "HEAD" });
+                expect(resp.status).to.eq(404);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
+                expect(resp.body).to.be.null
             })
         })
 
@@ -91,6 +140,22 @@ describe("backends/awsS3", () => {
             expect(resp.status).to.eq(200);
             for (let h in resp.headers)
                 expect(h.startsWith("x-amz-")).to.eq(false)
+            expect(resp.headers.get("etag")).to.not.be.empty
+        })
+
+        it("responds to HEAD requests correctly", async () => {
+            const fn = awsS3({
+                bucket: "flyio-private-website",
+                credentials: {
+                    accessKeyId: app.config.aws_s3_access_key_id,
+                    secretAccessKey: app.config.aws_s3_secret_access_key
+                }
+            });
+            const resp = await fn("/", { method: "HEAD" });
+            expect(resp.status).to.eq(200);
+            for (let h in resp.headers)
+                expect(h.startsWith("x-amz-")).to.eq(false)
+            expect(await resp.text()).to.be.empty
         })
     })
 

--- a/test/backends/aws_s3.spec.ts
+++ b/test/backends/aws_s3.spec.ts
@@ -5,24 +5,61 @@ const { awsS3 } = backends
 
 describe("backends/awsS3", () => {
     describe("public", () => {
-        it('works', async () => {
+        it("responds with the file's content", async () => {
             const fn = awsS3("flyio-test-website");
             const resp = await fn("/index.html");
             expect(resp.status).to.eq(200);
+            for (let h in resp.headers)
+                expect(h.startsWith("x-amz-")).to.eq(false)
         })
-    })
-
-    describe("w/ options", () => {
-        it('works', async () => {
-            const fn = awsS3({ bucket: "flyio-test-website" });
-            const resp = await fn("/index.html");
+        it("uses index.html by default", async () => {
+            const fn = awsS3("flyio-test-website");
+            const resp = await fn("/");
             expect(resp.status).to.eq(200);
+            for (let h in resp.headers)
+                expect(h.startsWith("x-amz-")).to.eq(false)
+        })
+        describe("w/ options", () => {
+            it("responds with the file's content", async () => {
+                const fn = awsS3({ bucket: "flyio-test-website" });
+                const resp = await fn("/index.html");
+                expect(resp.status).to.eq(200);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false)
+            })
+        })
+        describe("error handling", () => {
+            it("returns a 404 when file is not found", async () => {
+                const fn = awsS3({ bucket: "flyio-test-website" });
+                const resp = await fn("/index2.html");
+                expect(resp.status).to.eq(404);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
+            })
         })
     })
 
     describe("private", () => {
-        if (app.config.aws_s3_secret_access_key)
-            it('works', async () => {
+        describe("error handling", () => {
+            it("returns a 500 when credentials are off", async () => {
+                const fn = awsS3({
+                    bucket: "flyio-private-website",
+                    credentials: {
+                        accessKeyId: "gibberish",
+                        secretAccessKey: "gibberish"
+                    }
+                });
+                const resp = await fn("/index.html");
+                expect(resp.status).to.eq(500);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
+            })
+
+            if (!app.config.aws_s3_secret_access_key) {
+                it('500 when access denied might work (did not run, missing proper secrets)');
+                return
+            }
+            it("returns a 500 when a file is not found (aws: access denied)", async () => {
                 const fn = awsS3({
                     bucket: "flyio-private-website",
                     credentials: {
@@ -30,11 +67,31 @@ describe("backends/awsS3", () => {
                         secretAccessKey: app.config.aws_s3_secret_access_key
                     }
                 });
-                const resp = await fn("/index.html");
-                expect(resp.status).to.eq(200);
+                const resp = await fn("/index2.html");
+                expect(resp.status).to.eq(500);
+                for (let h in resp.headers)
+                    expect(h.startsWith("x-amz-")).to.eq(false) // just to make sure we don't leak
             })
-        else
-            it('works (did not run, missing proper secrets)')
+        })
+
+        if (!app.config.aws_s3_secret_access_key) {
+            it('might work (did not run, missing proper secrets)');
+            return
+        }
+
+        it('responds with the file', async () => {
+            const fn = awsS3({
+                bucket: "flyio-private-website",
+                credentials: {
+                    accessKeyId: app.config.aws_s3_access_key_id,
+                    secretAccessKey: app.config.aws_s3_secret_access_key
+                }
+            });
+            const resp = await fn("/index.html");
+            expect(resp.status).to.eq(200);
+            for (let h in resp.headers)
+                expect(h.startsWith("x-amz-")).to.eq(false)
+        })
     })
 
 })

--- a/webpack.fly.config.js
+++ b/webpack.fly.config.js
@@ -1,7 +1,12 @@
+let path = require('path')
+
 module.exports = {
   entry: "./index.ts",
   resolve: {
-    extensions: ['.js', '.ts', '.tsx']
+    extensions: ['.js', '.ts', '.tsx'],
+    alias: {
+      crypto: path.resolve(__dirname, 'src', 'shims', 'crypto'),
+    }
   },
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,11 @@
     htmlparser2 "^3.9.2"
     http-cache-semantics "^3.8.1"
 
+"@types/aws4@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@types/aws4/-/aws4-1.5.1.tgz#361fadab198a030ab398269183ae3fa86e958ed9"
+  integrity sha1-Nh+tqxmKAwqzmCaRg64/qG6Vjtk=
+
 "@types/chai@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
@@ -126,6 +131,11 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/sjcl@^1.0.28":
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/@types/sjcl/-/sjcl-1.0.28.tgz#4693eb6943e385e844a70fb25b4699db286c7214"
+  integrity sha1-RpPraUPjhehEpw+yW0aZ2yhschQ=
 
 "@types/source-map@^0.5.2":
   version "0.5.7"
@@ -302,6 +312,11 @@ async@^2.1.2, async@^2.5.0:
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 axios@^0.18.0:
   version "0.18.0"
@@ -3303,6 +3318,11 @@ simple-swizzle@^0.2.2:
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
   dependencies:
     is-arrayish "^0.3.1"
+
+sjcl@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/sjcl/-/sjcl-1.0.8.tgz#f2ec8d7dc1f0f21b069b8914a41a8f236b0e252a"
+  integrity sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Supports both public and private buckets.

We should add more options later such as prefix, transform function, "website" buckets (automatically resolve `.html`).